### PR TITLE
README: add example how to use a local hooks dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 debian/files
+*-ubuntu-bartender.log
+*-ubuntu-on-the-rocks.tar.gz

--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -71,6 +71,12 @@ ubuntu-bartender --livecd-rootfs-dir ~/local_livecd-rootfs # Use a local checkou
 ubuntu-bartender --chroot-archive local_rootfs.tar.gz # Use a different rootfs for the LXD container
 ```
 
+If you want to include some extra hooks from a local checkout, that can also be done:
+
+```
+ubuntu-bartender --livecd-rootfs-dir ~/local_livecd-rootfs --hook-extras-dir ~/local_hooks_dir
+```
+
 ## That's too many options, how can I keep track of them all?
 
 Use `--help` to list all available options for Ubuntu Bartender. The help text will update to include any configuration already specified.


### PR DESCRIPTION
When custom hooks are needed, it's useful to know that there is a
`--hook-extras-dir` option that can be used.