### PR TITLE
add ubuntu-bartender symlink to ubuntu-impish-bartender

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-impish-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-impish-bartender
@@ -1,0 +1,1 @@
+ubuntu-bartender


### PR DESCRIPTION
Impish Indri is the 21.10 codename for the next Ubuntu release so add
a symlink similar to the other symlinks for previous releases.