### PR TITLE
Add Azure as build provider

### DIFF
--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -61,6 +61,7 @@ Where do you want the VM to run? You can specify:
 
 ```
 ubuntu-bartender --build-provider aws # build on a remote AWS instance
+ubuntu-bartender --build-provider azure # build on a remote Azure instance
 ubuntu-bartender --build-provider multipass # build with a local multipass instance
 ```
 
@@ -125,6 +126,26 @@ AWS_KEYPAIR_NAME=aws_testing_keypair
 MULTIPASS_DISK_SIZE=multipass_disk_size
 MULTIPASS_MEM_SIZE=multipass_memory_size
 MULTIPASS_IMAGE=multipass_image
+```
+
+#### Azure
+
+To build on Azure, specify `--build-provider azure`. You will also need to provide a [location](https://azure.microsoft.com/en-us/global-infrastructure/geographies/) (region) via `--azure-location` (default to `France Central`); a public SSH key for connecting to the VM (via `--azure-pubkey-path`, default to `$HOME/.ssh/$USER.pub`). Finally you can provide a custom image "URN" (via `--azure-urn`, just use the default if you don't know what you do) and the Azure instance [size](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes) (type) with `--azure-instance-size` (default to `Standard_F8s_v2`).
+
+Example:
+
+```
+ubuntu-bartender \
+  --build-provider azure \
+  --azure-pubkey-path ~/.ssh/ubuntu.pub \
+  --azure-location "Germany West Central" \
+  \
+  --livecd-rootfs-branch ubuntu/focal \
+  -- \
+  --series focal \
+  --project ubuntu-cpc \
+  --subproject base \
+  --image-target kvm
 ```
 
 ## ARM builds

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -41,7 +41,7 @@ function build-provider-assert-ready {
 
 function build-provider-destroy {
   echo "Destroying group $1 on Azure..."
-  az group delete -y -g "$1" &> /dev/null
+  az group delete --no-wait -y -g "$1" &> /dev/null
 }
 
 function build-provider-create {

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -21,6 +21,12 @@ function build-provider-assert-ready {
     exit 255
   fi
 
+  if ! az account show &>/dev/null
+  then
+    echo "error: azure-cli is not configured, run: az login" >&2
+    exit 255
+  fi
+
   if ! command -v jq &>/dev/null
   then
     echo "error: jq was not found in PATH" >&2

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -1,6 +1,6 @@
 function _wait-instance-connectable() {
   for attempt in $(seq 12); do
-    if ! ssh -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
+    if ! ssh $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10
     else
       state=connectable
@@ -32,11 +32,6 @@ function build-provider-assert-ready {
     echo "error: jq was not found in PATH" >&2
     exit 255
   fi
-
-  if [ ! -f "$AZURE_PUBKEY_PATH" ]; then
-    echo "error: no such file $AZURE_PUBKEY_PATH" >&2
-    exit 255
-  fi
 }
 
 function build-provider-destroy {
@@ -45,6 +40,11 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
+  key_dir="$temp_dir/keys"
+  echo "Generating SSH key in $key_dir"
+  mkdir "$key_dir"
+  ssh-keygen -t rsa -f "$temp_dir/keys/ubuntu" -P '' &> /dev/null
+
   echo "Creating $1 on Azure..."
   az group create -l "$AZURE_LOCATION" -g "$1" &> /dev/null
   ip_addr=$(az vm create --name "$1" \
@@ -52,20 +52,29 @@ function build-provider-create {
                --image "$AZURE_URN" \
                --size "$AZURE_INSTANCE_SIZE" \
                --admin-username ubuntu \
-               --ssh-key-value "$(cat "$AZURE_PUBKEY_PATH")" 2> /dev/null |
+               --ssh-key-value "$key_dir/ubuntu.pub" 2> /dev/null |
                jq -r '.publicIpAddress')
   _wait-instance-connectable
 }
 
 function build-provider-upload {
-  scp -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
+  scp $(set-key-opt) -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
 }
 
 function build-provider-download {
-  scp -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
+  scp $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
 }
 
 function build-provider-run {
   args=$(echo -- $@ | sed 's/.*--//')
-  ssh -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+  ssh $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+}
+
+function set-key-opt() {
+  export KEY_OPT=''
+  if [ -f "$temp_dir/keys/ubuntu" ]; then
+    KEY_OPT="-i $temp_dir/keys/ubuntu"
+  fi
+
+  echo ${KEY_OPT}
 }

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -1,0 +1,65 @@
+function _wait-instance-connectable() {
+  for attempt in $(seq 12); do
+    if ! ssh -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
+      sleep 10
+    else
+      state=connectable
+      break
+    fi
+  done
+
+  if [ "$state" != "connectable" ]; then
+    echo "error: instance not 'connectable' after 2 minutes"
+    exit 255
+  fi
+}
+
+function build-provider-assert-ready {
+  if ! command -v az &>/dev/null
+  then
+    echo "error: azure-cli was not found in PATH" >&2
+    exit 255
+  fi
+
+  if ! command -v jq &>/dev/null
+  then
+    echo "error: jq was not found in PATH" >&2
+    exit 255
+  fi
+
+  if [ ! -f "$AZURE_PUBKEY_PATH" ]; then
+    echo "error: no such file $AZURE_PUBKEY_PATH" >&2
+    exit 255
+  fi
+}
+
+function build-provider-destroy {
+  echo "Destroying group $1 on Azure..."
+  az group delete -y -g "$1" > /dev/null 2>&1
+}
+
+function build-provider-create {
+  echo "Creating $1 on Azure..."
+  az group create -l "$AZURE_LOCATION" -g "$1" > /dev/null 2>&1
+  ip_addr=$(az vm create --name "$1" \
+               --resource-group "$1" \
+               --image "$AZURE_URN" \
+               --size "$AZURE_INSTANCE_SIZE" \
+               --admin-username ubuntu \
+               --ssh-key-value "$(cat "$AZURE_PUBKEY_PATH")" 2> /dev/null |
+               jq -r '.publicIpAddress')
+  _wait-instance-connectable
+}
+
+function build-provider-upload {
+  scp -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
+}
+
+function build-provider-download {
+  scp -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
+}
+
+function build-provider-run {
+  args=$(echo -- $@ | sed 's/.*--//')
+  ssh -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+}

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -41,12 +41,12 @@ function build-provider-assert-ready {
 
 function build-provider-destroy {
   echo "Destroying group $1 on Azure..."
-  az group delete -y -g "$1" > /dev/null 2>&1
+  az group delete -y -g "$1" &> /dev/null
 }
 
 function build-provider-create {
   echo "Creating $1 on Azure..."
-  az group create -l "$AZURE_LOCATION" -g "$1" > /dev/null 2>&1
+  az group create -l "$AZURE_LOCATION" -g "$1" &> /dev/null
   ip_addr=$(az vm create --name "$1" \
                --resource-group "$1" \
                --image "$AZURE_URN" \

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -113,7 +113,6 @@ MULTIPASS_IMAGE=daily:b # daily image of bionic
 # AZURE SPECIFIC DEFAULTS
 AZURE_URN="Canonical:UbuntuServer:18_04-daily-lts-gen2:latest"
 AZURE_INSTANCE_SIZE="Standard_F8s_v2"
-AZURE_PUBKEY_PATH="$HOME/.ssh/$USER.pub"
 AZURE_LOCATION="France Central"
 
 # We also pull in explicitly set variables on the command line
@@ -192,10 +191,6 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
     --azure-instance-size <size>            Azure instance size
                                             Value: $AZURE_INSTANCE_SIZE
-
-    --azure-pubkey-path <path>              SSH key to use to create/authenticate to
-                                            Azure instances.
-                                            Value: $AZURE_PUBKEY_PATH
 
     --azure-location <location>             Location (region) where to create the instance
                                             on Azure
@@ -307,10 +302,6 @@ do
       ;;
     --azure-instance-size)
       AZURE_INSTANCE_SIZE="$2"
-      shift
-      ;;
-    --azure-pubkey-path)
-      AZURE_PUBKEY_PATH="$2"
       shift
       ;;
     --azure-location)

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -110,6 +110,12 @@ MULTIPASS_DISK_SIZE=50G
 MULTIPASS_MEM_SIZE=8G
 MULTIPASS_IMAGE=daily:b # daily image of bionic
 
+# AZURE SPECIFIC DEFAULTS
+AZURE_URN="Canonical:0001-com-ubuntu-pro-bionic:pro-18_04-lts:latest"
+AZURE_INSTANCE_SIZE="Standard_F8s_v2"
+AZURE_PUBKEY_PATH="$HOME/.ssh/$USER.pub"
+AZURE_LOCATION="France Central"
+
 # We also pull in explicitly set variables on the command line
 
 function print-usage {
@@ -176,10 +182,24 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
     --aws-instance-type                     EC2 instance type. default is m5.large.
                                             m6g.large is a good choice for arm
-                                            value: $AWS_INSTANCE_TYPE
+                                            Value: $AWS_INSTANCE_TYPE
 
     --aws-arm-build                         Short hand switch for safe arm64 defaults
                                             This will override --aws-instance-type and --aws-ami-name-filter
+
+    --azure-urn                             Image URN
+                                            Value: $AZURE_URN
+
+    --azure-instance-size                   Azure instance size
+                                            Value: $AZURE_INSTANCE_SIZE
+
+    --azure-pubkey-path                     SSH key to use to create/authenticate to
+                                            Azure instances.
+                                            Value: $AZURE_PUBKEY_PATH
+
+    --azure-location                        Location (region) where to create the instance
+                                            on Azure
+                                            Value: $AZURE_LOCATION
 
     --temp-dir-loc                          Parent folder to build the temp dir used
                                             by bartender; note that this must be
@@ -280,6 +300,22 @@ do
       ;;
     --aws-arm-build)
       AWS_ARM_BUILD=true
+      ;;
+    --azure-urn)
+      AZURE_URN="$2"
+      shift
+      ;;
+    --azure-instance-size)
+      AZURE_INSTANCE_SIZE="$2"
+      shift
+      ;;
+    --azure-pubkey-path)
+      AZURE_PUBKEY_PATH="$2"
+      shift
+      ;;
+    --azure-location)
+      AZURE_LOCATION="$2"
+      shift
       ;;
     --temp-dir-loc)
       TEMP_DIR_LOC="$2"

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -111,7 +111,7 @@ MULTIPASS_MEM_SIZE=8G
 MULTIPASS_IMAGE=daily:b # daily image of bionic
 
 # AZURE SPECIFIC DEFAULTS
-AZURE_URN="Canonical:0001-com-ubuntu-pro-bionic:pro-18_04-lts:latest"
+AZURE_URN="Canonical:UbuntuServer:18_04-daily-lts-gen2:latest"
 AZURE_INSTANCE_SIZE="Standard_F8s_v2"
 AZURE_PUBKEY_PATH="$HOME/.ssh/$USER.pub"
 AZURE_LOCATION="France Central"

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -187,17 +187,17 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
     --aws-arm-build                         Short hand switch for safe arm64 defaults
                                             This will override --aws-instance-type and --aws-ami-name-filter
 
-    --azure-urn                             Image URN
+    --azure-urn <urn>                       Image URN
                                             Value: $AZURE_URN
 
-    --azure-instance-size                   Azure instance size
+    --azure-instance-size <size>            Azure instance size
                                             Value: $AZURE_INSTANCE_SIZE
 
-    --azure-pubkey-path                     SSH key to use to create/authenticate to
+    --azure-pubkey-path <path>              SSH key to use to create/authenticate to
                                             Azure instances.
                                             Value: $AZURE_PUBKEY_PATH
 
-    --azure-location                        Location (region) where to create the instance
+    --azure-location <location>             Location (region) where to create the instance
                                             on Azure
                                             Value: $AZURE_LOCATION
 


### PR DESCRIPTION
Because why not?

It can be actually useful to avoid having to upload Azure images (30GB, sparse) from my personal laptop to my Azure storage account. If using `--no-cleanup`, then connecting to the VM when the build is done, one can directly upload the images from Azure to Azure.