### PR TITLE
Cap default multipass memory usage to 50%

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -107,7 +107,12 @@ AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
-MULTIPASS_MEM_SIZE=8G
+
+# By default, do not exceed half the total memory.
+TOTAL_MEM=$(free -m | grep -oP '\d+' | head -n 1)
+MULTIPASS_MEM_SIZE="$(( ${TOTAL_MEM} / 2 ))M"
+# MULTIPASS_MEM_SIZE=8G  # you can optionally override this
+
 MULTIPASS_IMAGE=daily:b # daily image of bionic
 
 # We also pull in explicitly set variables on the command line

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -107,6 +107,7 @@ AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
+# MULTIPASS_MEM_SIZE=8G  # you can optionally override this
 MULTIPASS_IMAGE=daily:b # daily image of bionic
 
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).
@@ -116,12 +117,12 @@ HALF_MEM="$(( $TOTAL_MEM / 2 ))"
 CAP_MEM=8192
 
 if [[ "$HALF_MEM" -lt "$CAP_MEM" ]]; then
-    MULTIPASS_MEM_SIZE="${HALF_MEM}M"
+    MULTIPASS_MEM_SIZE_DEFAULT="${HALF_MEM}M"
 else
-    MULTIPASS_MEM_SIZE="${CAP_MEM}M"
+    MULTIPASS_MEM_SIZE_DEFAULT="${CAP_MEM}M"
 fi
 
-# MULTIPASS_MEM_SIZE=8G  # you can optionally override this
+MULTIPASS_MEM_SIZE=${MULTIPASS_MEM_SIZE:-$MULTIPASS_MEM_SIZE_DEFAULT}
 
 # We also pull in explicitly set variables on the command line
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -107,8 +107,8 @@ AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
-# MULTIPASS_MEM_SIZE=8G  # you can optionally override this
 MULTIPASS_IMAGE=daily:b # daily image of bionic
+# you can optionally override memory cap by setting MULTIPASS_MEM_SIZE
 
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).
 # All calculations are in MiB

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -112,7 +112,7 @@ MULTIPASS_IMAGE=daily:b # daily image of bionic
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).
 # All calculations are in MiB
 TOTAL_MEM=$(free -m | grep -oP '\d+' | head -n 1)
-HALF_MEM="$(( ${TOTAL_MEM} / 2 ))"
+HALF_MEM="$(( $TOTAL_MEM / 2 ))"
 CAP_MEM=8192
 
 if [[ "$HALF_MEM" -lt "$CAP_MEM" ]]; then

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -107,13 +107,21 @@ AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
-
-# By default, do not exceed half the total memory.
-TOTAL_MEM=$(free -m | grep -oP '\d+' | head -n 1)
-MULTIPASS_MEM_SIZE="$(( ${TOTAL_MEM} / 2 ))M"
-# MULTIPASS_MEM_SIZE=8G  # you can optionally override this
-
 MULTIPASS_IMAGE=daily:b # daily image of bionic
+
+# By default, do not exceed half the total memory or 8GiB (whichever is smaller).
+# All calculations are in MiB
+TOTAL_MEM=$(free -m | grep -oP '\d+' | head -n 1)
+HALF_MEM="$(( ${TOTAL_MEM} / 2 ))"
+CAP_MEM=8192
+
+if [[ "$HALF_MEM" -lt "$CAP_MEM" ]]; then
+    MULTIPASS_MEM_SIZE="${HALF_MEM}M"
+else
+    MULTIPASS_MEM_SIZE="${CAP_MEM}M"
+fi
+
+# MULTIPASS_MEM_SIZE=8G  # you can optionally override this
 
 # We also pull in explicitly set variables on the command line
 


### PR DESCRIPTION
The old default of 8G was likely set on the assumption that all
developers have at least 16G of memory. As a result, running
Bartender w/ Multipass on a 12G (~11.5 working) system concurrent
with a few normal processes (~5G used) resulted in an OutOfMemory
crash (8G+5G=13G > 11.5G). By capping the memory at 50%, 16G
systems can still cap multipass at ~8G, but systems with less
RAM do not run a high risk of an OutOfMemory crash.