### PR TITLE
(feat) Migrate to Focal

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ manage the Ubuntu Old Fashioned build for you.
 
 ## Installation
 
-On Ubuntu (**only works for Bionic or Xenial**):
+On Ubuntu (**works for Focal, Bionic or Xenial**):
 
 The easiest way to install is to use the included setup script:
 

--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -26,7 +26,7 @@ Absolutely. Here's an incomplete, high-level overview of the components
 of an Ubuntu image build with Ubuntu Bartender:
 
 #### [Ubuntu Bartender][3]
-- Manages the lifecycle of a bionic VM in which the image build is run
+- Manages the lifecycle of a VM in which the image build is run
 - Collects the dependencies of an Ubuntu Old Fashioned image build
 - Runs an Ubuntu Old Fashioned image build
 - Downloads any artifacts produced by the build
@@ -106,7 +106,7 @@ ubuntu-bartender --help
 
 ## You mentioned an example specifying different build providers. Why does that matter?
 
-The Ubuntu image build happens in a LXD container within a bionic VM. Ubuntu Bartender can manage the lifecycle of that VM, which can run in either [Multipass][7] or [AWS][8].
+The Ubuntu image build happens in a LXD container within an Ubuntu VM. Ubuntu Bartender can manage the lifecycle of that VM, which can run in either [Multipass][7] or [AWS][8].
 
 Multipass is more convenient - all of your VMs run locally and it's free.
 
@@ -160,7 +160,7 @@ ARM is growing in support, and there is demand for builds. However, most of us d
 There is a quick option for calling up ARM defaults for aws, `--aws-arm-build` (AWS_ARM_BUILD). This is a boolean style flag, so via the cli, passing the flag is sufficient
 For configuration in file or env_var, please use true or false (literal strings). The only truthy value is the literal string "true". 
 
-This will run a build searching for an ARM based ami (`AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*"`) and 
+This will run a build searching for an ARM based ami (`AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-focal-daily-arm64-server-*"`) and 
 use an arm instance type (`AWS_INSTANCE_TYPE="m6g.large"`). This option is meant as a quick flag so you don't need to look up filter name or instance types.
 
 Know that setting `--aws-ami-name-filter` and `--aws-instance-type` **and** `--aws-arm-build` will result in the `--aws-arm-build` defaults being used, **not** your passed in values.

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -1,5 +1,12 @@
+function az_cleanup {
+  echo "Cleaning up..."
+  rm -rf $temp_dir
+  build-provider-destroy $bartender_name
+}
+
 function _wait-instance-connectable() {
-  for attempt in $(seq 12); do
+  # wait for the VM to be running before checking SSH
+  for attempt in $(seq 6); do
     if ! ssh $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10
     else
@@ -40,6 +47,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
+  trap "az_cleanup" EXIT
   key_dir="$temp_dir/keys"
   echo "Generating SSH key in $key_dir"
   mkdir "$key_dir"
@@ -48,20 +56,7 @@ function build-provider-create {
   echo "Creating $1 Resource Group and VM on Azure..."
   az group create -l "$AZURE_LOCATION" -g "$1" &> /dev/null
   # there can be a lag in resource group creation, which leads to VMs never getting made
-  for attempt in $(seq 6); do
-    rg_state=requested
-    rg_exists=$(az group exists --name "$1")
-    if [ rg_exists = "false" ]; then
-      sleep 10
-    else
-      rg_state=created
-      break
-    fi
-  done
-  if [ $rg_state  != "created" ]; then
-    echo "failed to create resource group $1"
-    exit 255
-  fi
+  az group wait --created --timeout 600 --interval 10 --name $1
   ip_addr=$(az vm create --name "$1" \
                --resource-group "$1" \
                --image "$AZURE_URN" \
@@ -69,6 +64,14 @@ function build-provider-create {
                --admin-username ubuntu \
                --ssh-key-value "$key_dir/ubuntu.pub" 2> /dev/null |
                jq -r '.publicIpAddress')
+  # wait for VM running before checking instance connection
+  echo "Waiting for VM creation and connectability to $1"
+  az vm wait --resource-group $1 --name $1 --custom "instanceView.statuses[?code=='PowerState/running']" --timeout 300 --interval 10
+  # sometimes the az vm create command can return without a public IP up yet
+  if [ -z $ip_addr ]; then
+    ip_addr=$(az vm list-ip-addresses --name $1 --resource-group $1 --query "[].virtualMachine.network.publicIpAddresses[0].ipAddress[0]" --output tsv)
+  fi
+  echo $ip_addr
   _wait-instance-connectable
 }
 

--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -45,8 +45,23 @@ function build-provider-create {
   mkdir "$key_dir"
   ssh-keygen -t rsa -f "$temp_dir/keys/ubuntu" -P '' &> /dev/null
 
-  echo "Creating $1 on Azure..."
+  echo "Creating $1 Resource Group and VM on Azure..."
   az group create -l "$AZURE_LOCATION" -g "$1" &> /dev/null
+  # there can be a lag in resource group creation, which leads to VMs never getting made
+  for attempt in $(seq 6); do
+    rg_state=requested
+    rg_exists=$(az group exists --name "$1")
+    if [ rg_exists = "false" ]; then
+      sleep 10
+    else
+      rg_state=created
+      break
+    fi
+  done
+  if [ $rg_state  != "created" ]; then
+    echo "failed to create resource group $1"
+    exit 255
+  fi
   ip_addr=$(az vm create --name "$1" \
                --resource-group "$1" \
                --image "$AZURE_URN" \

--- a/scripts/ubuntu-bartender/gce-provider
+++ b/scripts/ubuntu-bartender/gce-provider
@@ -43,7 +43,7 @@ function build-provider-create {
 
   echo "Creating $1 on GCE..."
   ip_addr=$(gcloud compute instances create "$1" \
-     --image-family ubuntu-1804-lts \
+     --image-family $GCE_IMAGE \
      --image-project ubuntu-os-cloud \
      --metadata-from-file=ssh-keys="$temp_dir/keys/metadata" \
      --boot-disk-size=50GB \

--- a/scripts/ubuntu-bartender/gce-provider
+++ b/scripts/ubuntu-bartender/gce-provider
@@ -43,7 +43,7 @@ function build-provider-create {
 
   echo "Creating $1 on GCE..."
   ip_addr=$(gcloud compute instances create "$1" \
-     --image-family $GCE_IMAGE \
+     --image-family $GCE_IMAGE_FAMILY \
      --image-project ubuntu-os-cloud \
      --metadata-from-file=ssh-keys="$temp_dir/keys/metadata" \
      --boot-disk-size=50GB \

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -132,7 +132,7 @@ AZURE_LOCATION="France Central"
 # GCE SPECIFIC DEFAULTS
 GCE_MACHINE_TYPE="n2-standard-2"
 GCE_ZONE="europe-west3-a"
-GCE_IMAGE="ubuntu-2004-lts"
+GCE_IMAGE_FAMILY="ubuntu-2004-lts"
 
 # We also pull in explicitly set variables on the command line
 
@@ -220,8 +220,8 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
     --gce-zone <zone>                       Zone in which to create the GCE instance
                                             Value: $GCE_ZONE
     
-    --gce-image <image>                     GCE Image to use
-                                            VALUE: $GCE_IMAGE
+    --gce-image-family <image>              GCE Image Famiy to use
+                                            VALUE: $GCE_IMAGE_FAMILY
 
     --temp-dir-loc                          Parent folder to build the temp dir used
                                             by bartender; note that this must be
@@ -344,7 +344,7 @@ do
       shift
       ;;
     --gce-image)
-      GCE_IMAGE="$2"
+      GCE_IMAGE_FAMILY="$2"
       shift
       ;;
     --temp-dir-loc)

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -97,7 +97,6 @@ fi
 # Please preface each provider default with the provider name
 
 # AWS SPECIFIC DEFAULTS
-AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-amd64-server-*"
 AWS_PROFILE="default"
 AWS_INSTANCE_TYPE="m5.large"
 # Official Canonical OwnerId
@@ -105,9 +104,10 @@ AWS_AMI_OWNER=099720109477
 AWS_KEYPAIR_NAME=$USER
 AWS_ARM_BUILD=false
 
+
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
-MULTIPASS_IMAGE=daily:b # daily image of bionic
+MULTIPASS_IMAGE=daily:f # daily image of bionic
 # you can optionally override memory cap by setting MULTIPASS_MEM_SIZE
 
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).
@@ -125,13 +125,14 @@ fi
 MULTIPASS_MEM_SIZE=${MULTIPASS_MEM_SIZE:-$MULTIPASS_MEM_SIZE_DEFAULT}
 
 # AZURE SPECIFIC DEFAULTS
-AZURE_URN="Canonical:UbuntuServer:18_04-daily-lts-gen2:latest"
+AZURE_URN="Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts-gen2:latest"
 AZURE_INSTANCE_SIZE="Standard_F8s_v2"
 AZURE_LOCATION="France Central"
 
 # GCE SPECIFIC DEFAULTS
 GCE_MACHINE_TYPE="n2-standard-2"
 GCE_ZONE="europe-west3-a"
+GCE_IMAGE="ubuntu-2004-lts"
 
 # We also pull in explicitly set variables on the command line
 
@@ -178,10 +179,9 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             Value: Cleanup? $SHOULD_CLEANUP
 
     --aws-ami-name-filter <image-name>      Filter for finding an AWS ami by name
-                                            defaults to Bionic AMD64. This is
-                                            the base for the builds. for ARM:
-                                            ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*
-                                            Value: $AWS_AMI_NAME_FILTER
+                                            defaults to Focal AMD64. This is
+                                            the base for the builds. 
+                                            Value: ubuntu/images-testing/hvm-ssd/ubuntu-focal-daily-${ARCH}-server-*
 
     --aws-profile <profile>                 AWS profile used with the aws cli
                                             Value: $AWS_PROFILE
@@ -219,6 +219,9 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
     --gce-zone <zone>                       Zone in which to create the GCE instance
                                             Value: $GCE_ZONE
+    
+    --gce-image <image>                     GCE Image to use
+                                            VALUE: $GCE_IMAGE
 
     --temp-dir-loc                          Parent folder to build the temp dir used
                                             by bartender; note that this must be
@@ -340,6 +343,10 @@ do
       GCE_ZONE="$2"
       shift
       ;;
+    --gce-image)
+      GCE_IMAGE="$2"
+      shift
+      ;;
     --temp-dir-loc)
       TEMP_DIR_LOC="$2"
       shift
@@ -378,9 +385,13 @@ fi
 if [ "$AWS_ARM_BUILD" = "true" ]
 then
   AWS_INSTANCE_TYPE="m6g.large"
-  AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*"
+  AWS_ARCH="arm64"
   BUILD_PROVIDER="aws"
+else
+  AWS_ARCH="amd64"
 fi
+
+AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-focal-daily-${AWS_ARCH}-server-*"
 
 # Verify that the specified build provider is available and ready
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -107,7 +107,7 @@ AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
-MULTIPASS_IMAGE=daily:f # daily image of bionic
+MULTIPASS_IMAGE=daily:focal
 # you can optionally override memory cap by setting MULTIPASS_MEM_SIZE
 
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).


### PR DESCRIPTION
20220222, Lauchpad Builders migrated to Focal for the underlying VMs.
This aligns ubuntu-bartender's automated support, and updates
old-fashioned's statements on what Ubuntu versions are supported.

also adds the ability to configure GCE host vms in case of future
changes or wishing to do work on a specific image. This was supported in
other providers already