### PR TITLE
Add remove package.build step

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -432,6 +432,8 @@ build-provider-create $bartender_name
 
   if [ -n "$HOOK_EXTRAS_DIR" ]
   then
+    echo "Removing package.build from local cpc_packaging.extra..." >&2
+    rm -rf "$HOOK_EXTRAS_DIR"/package.build
     cp -aR "$HOOK_EXTRAS_DIR" $temp_dir/extras
   fi
 


### PR DESCRIPTION
Very often people will make a package to dput to their PPA, but forget
to remove the package.build artifact from their local hooks dir.
Using bartender with ``--hook-extras-dir`` set and this package.build
directory present causes all sort of weird issues, so let's just remove
it before bartender gets down to business.

I also am conscious I've added a big ugly echo line out that disturbs the nice
````
Preparing ingredients...
Mixing drink...
(See progress in in-grubworm-ubuntu-bartender.log)
Pouring in-grubworm-ubuntu-on-the-rocks.tar.gz...
Cleaning up..
````
flow... if people would prefer we didn't echo anything just let me know