### PR TITLE
Feature/nest release notes tools

### DIFF
--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -70,7 +70,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
-  echo "Creating $1 on AWS..."
+  echo "Creating $1 on AWS... with profile ${AWS_PROFILE} in region ${region} using ${AWS_KEYPAIR_NAME} keypair"
   instance_id=$(aws --output json --region "$region" \
                     --profile "$AWS_PROFILE" \
                     ec2 run-instances \

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -57,10 +57,12 @@ UBUNTU_OLD_FASHIONED_REPO=${UBUNTU_OLD_FASHIONED_REPO:-https://github.com/ubuntu
 LIVECD_ROOTFS_REPO=${LIVECD_ROOTFS_REPO:-https://git.launchpad.net/livecd-rootfs}
 HOOK_EXTRAS_REPO=${HOOK_EXTRAS_REPO:-}
 HOOK_EXTRAS_DIR=${HOOK_EXTRAS_DIR:-}
+HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO=${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO:-}
 
 # And any specific branches for each that should be used:
 
 UBUNTU_OLD_FASHIONED_BRANCH=${UBUNTU_OLD_FASHIONED_BRANCH:-master}
+HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH=${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH:-}
 # LIVECD_ROOTFS_BRANCH is inferred below from the script name
 HOOK_EXTRAS_BRANCH=${HOOK_EXTRAS_BRANCH:-}
 
@@ -162,6 +164,12 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
     --hook-extras-branch <branch>           The branch of the extras-repo to use.
                                             Value: ${HOOK_EXTRAS_BRANCH:-None}
+
+    --hook-extras-release-notes-tools-repo <url> The url to a git repo hosting release notes tools.
+                                            Value: ${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO:-None}
+
+    --hook-extras-release-notes-tools-branch <branch> The branch of the release-notes-tools to use.
+                                            Value: ${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH:-None}
 
     --hook-extras-dir <dir>                 A local directory containing extra hooks.
                                             Value: ${HOOK_EXTRAS_DIR:-None}
@@ -284,6 +292,14 @@ do
       ;;
     --hook-extras-dir)
       HOOK_EXTRAS_DIR="$2"
+      shift
+      ;;
+    --hook-extras-release-notes-tools-repo)
+      HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO="$2"
+      shift
+      ;;
+    --hook-extras-release-notes-tools-branch)
+      HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH="$2"
       shift
       ;;
     --chroot-archive)
@@ -428,7 +444,7 @@ fi
 build-provider-create $bartender_name
 
 (
-  echo "Preparing ingredients..."
+  echo "Preparing ingredients... in $temp_dir"
 
   if [ -n "$HOOK_EXTRAS_DIR" ]
   then
@@ -477,6 +493,23 @@ build-provider-create $bartender_name
   then
     find livecd-rootfs/live-build/ -type d -name '*hooks*' |
       xargs -I {} cp -af extras/* {}
+  fi
+
+  if [ -n "$HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO" ]
+  then
+    branch_flag=" "
+    if [ -n "$HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH" ]
+    then
+      branch_flag="-b $HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH"
+    fi
+    git clone -q $branch_flag $HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO release-notes-tools
+  fi
+
+  if [ -d $temp_dir/release-notes-tools ]
+  then
+    # copy the release notes tools to all the hooks directories
+    find livecd-rootfs/live-build/ -type d -name '*hooks*' |
+      xargs -I {} sh -c 'mkdir --parents {}/extra/release-notes-tools && cp --archive --force release-notes-tools/* {}/extra/release-notes-tools/'
   fi
 
   cat > mix-old-fashioned << EOF


### PR DESCRIPTION
feat: Add flag to nest release notes tools in */hooks.d/extra/release-notes-tools directory

By default this is empty but you can use the public repo https://git.launchpad.net/~cloud-images/cloud-images/+git/cpc-release-notes-tools

```
--hook-extras-release-notes-tools-repo "https://git.launchpad.net/~cloud-images/cloud-images/+git/cpc-release-notes-tools" \
--hook-extras-release-notes-tools-branch "main"
```

Any tools or scripts can then be used during image builds. This means we can iterate and manage this tooling outside of
livecd-rootfs or any other extras repos
