### PR TITLE
feat: Add flag to nest sbom tools in */hooks.d/extra/sbom-tools directory

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -58,11 +58,15 @@ LIVECD_ROOTFS_REPO=${LIVECD_ROOTFS_REPO:-https://git.launchpad.net/livecd-rootfs
 HOOK_EXTRAS_REPO=${HOOK_EXTRAS_REPO:-}
 HOOK_EXTRAS_DIR=${HOOK_EXTRAS_DIR:-}
 HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO=${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO:-}
+HOOK_EXTRAS_SBOM_TOOLS_REPO=${HOOK_EXTRAS_SBOM_TOOLS_REPO:-}
 
 # And any specific branches for each that should be used:
 
 UBUNTU_OLD_FASHIONED_BRANCH=${UBUNTU_OLD_FASHIONED_BRANCH:-master}
 HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH=${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH:-}
+HOOK_EXTRAS_SBOM_TOOLS_BRANCH=${HOOK_EXTRAS_SBOM_TOOLS_BRANCH:-}
+HOOK_EXTRAS_SBOM_TOOLS_DIR=${HOOK_EXTRAS_SBOM_TOOLS_DIR:-}
+
 # LIVECD_ROOTFS_BRANCH is inferred below from the script name
 HOOK_EXTRAS_BRANCH=${HOOK_EXTRAS_BRANCH:-}
 
@@ -170,6 +174,16 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
     --hook-extras-release-notes-tools-branch <branch> The branch of the release-notes-tools to use.
                                             Value: ${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH:-None}
+
+    --hook-extras-sbom-tools-repo <url>     The url to a git repo hosting sbom tools.
+                                            Value: ${HOOK_EXTRAS_SBOM_TOOLS_REPO:-None}
+
+    --hook-extras-sbom-tools-branch <branch> The branch of the sbom-tools to use.
+                                            Value: ${HOOK_EXTRAS_SBOM_TOOLS_BRANCH:-None}
+
+    --hook-extras-sbom-tools-dir <dir>      The directory in the sbom-tools to copy in to hooks.d/extra directories.
+                                            This is useful as you don't always want to copy the entire sbom-tools repo.
+                                            Value: ${HOOK_EXTRAS_SBOM_TOOLS_DIR:-None}
 
     --hook-extras-dir <dir>                 A local directory containing extra hooks.
                                             Value: ${HOOK_EXTRAS_DIR:-None}
@@ -300,6 +314,18 @@ do
       ;;
     --hook-extras-release-notes-tools-branch)
       HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH="$2"
+      shift
+      ;;
+    --hook-extras-sbom-tools-repo)
+      HOOK_EXTRAS_SBOM_TOOLS_REPO="$2"
+      shift
+      ;;
+    --hook-extras-sbom-tools-branch)
+      HOOK_EXTRAS_SBOM_TOOLS_BRANCH="$2"
+      shift
+      ;;
+    --hook-extras-sbom-tools-dir)
+      HOOK_EXTRAS_SBOM_TOOLS_DIR="$2"
       shift
       ;;
     --chroot-archive)
@@ -509,7 +535,24 @@ build-provider-create $bartender_name
   then
     # copy the release notes tools to all the hooks directories
     find livecd-rootfs/live-build/ -type d -name '*hooks*' |
-      xargs -I {} sh -c 'mkdir --parents {}/extra/release-notes-tools && cp --archive --force release-notes-tools/* {}/extra/release-notes-tools/'
+      xargs -I {} sh -c "mkdir --parents {}/extra/release-notes-tools && cp --archive --force $temp_dir/release-notes-tools/* {}/extra/release-notes-tools/"
+  fi
+
+  if [ -n "$HOOK_EXTRAS_SBOM_TOOLS_REPO" ]
+  then
+    branch_flag=" "
+    if [ -n "$HOOK_EXTRAS_SBOM_TOOLS_BRANCH" ]
+    then
+      branch_flag="-b $HOOK_EXTRAS_SBOM_TOOLS_BRANCH"
+    fi
+    git clone -q $branch_flag $HOOK_EXTRAS_SBOM_TOOLS_REPO sbom-tools
+  fi
+
+  if [ -d $temp_dir/sbom-tools ]
+  then
+    # copy the sbom tools to all the hooks directories
+    find livecd-rootfs/live-build/ -type d -name '*hooks*' |
+      xargs -I {} sh -c "mkdir --parents {}/extra/sbom-tools && cp --archive --force $temp_dir/sbom-tools/${HOOK_EXTRAS_SBOM_TOOLS_DIR}/* {}/extra/sbom-tools/"
   fi
 
   cat > mix-old-fashioned << EOF


### PR DESCRIPTION
By default this is empty

```
--hook-extras-sbom-repo "${YOUR_SBOM_TOOLS_REPO}" \
--hook-extras-sbom-branch "main"
--hook-extras-sbom-dir "${YOUR_SBOM_TOOLS_REPO_SUBDIRECTORY_TO_NEST}"
```

This means we can iterate and manage this tooling outside of livecd-rootfs or any other extras repos