### PR TITLE
Fix deprecation warning for multipass provider

### DIFF
--- a/scripts/ubuntu-bartender/multipass-provider
+++ b/scripts/ubuntu-bartender/multipass-provider
@@ -11,7 +11,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
-  multipass launch --disk $MULTIPASS_DISK_SIZE --mem $MULTIPASS_MEM_SIZE --name "$1" $MULTIPASS_IMAGE
+  multipass launch --disk $MULTIPASS_DISK_SIZE --memory $MULTIPASS_MEM_SIZE --name "$1" $MULTIPASS_IMAGE
 }
 
 function build-provider-upload {


### PR DESCRIPTION
This fixes:

warning: "--mem" long option will be deprecated in favour of \
  "--memory" in a future release.Please update any scripts, etc.