### PR TITLE
feat: Add ARM64 builds for GCE

### DIFF
--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -62,6 +62,7 @@ Where do you want the VM to run? You can specify:
 ```
 ubuntu-bartender --build-provider aws # build on a remote AWS instance
 ubuntu-bartender --build-provider azure # build on a remote Azure instance
+ubuntu-bartender --build-provider gce # build on a remote GCE instance
 ubuntu-bartender --build-provider multipass # build with a local multipass instance
 ```
 
@@ -154,17 +155,44 @@ ubuntu-bartender \
   --image-target kvm
 ```
 
-## ARM builds
-ARM is growing in support, and there is demand for builds. However, most of us do not have an ARM based daily driver for development. Thankfully, AWS to the rescue
+#### GCE
 
-There is a quick option for calling up ARM defaults for aws, `--aws-arm-build` (AWS_ARM_BUILD). This is a boolean style flag, so via the cli, passing the flag is sufficient
+To build on GCE, please specify `--build-provider gce`. You will need `gcloud` installed locally and set up with
+`gcloud init` (see https://cloud.google.com/sdk/gcloud/reference/init for instructions if unsure)
+
+Example:
+```
+ ubuntu-bartender \
+ --build-provider gce \
+ --gce-zone europe-west2-a \
+ --gce-machine-type n2-standard-8 \
+ --hook-extras-dir "/path/to/extra/hooks/dir" \
+ --livecd-rootfs-branch ubuntu/jammy \
+ -- \
+ --series jammy \
+ --project ubuntu-cpc \
+ --subproject base \
+ --image-target gce
+```
+
+## ARM builds
+ARM is growing in support, and there is demand for builds. However, most of us do not have an ARM based daily driver for development. Thankfully, AWS and GCE have come to the rescue!
+
+There is a quick option for calling up ARM defaults for aws, `--aws-arm-build` (AWS_ARM_BUILD) and GCE `--gce-arm-build` (GCE_ARM_BUILD).
+This is a boolean style flag, so via the cli, passing the flag is sufficient . 
 For configuration in file or env_var, please use true or false (literal strings). The only truthy value is the literal string "true". 
 
+### AWS ARM builds
 This will run a build searching for an ARM based ami (`AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*"`) and 
 use an arm instance type (`AWS_INSTANCE_TYPE="m6g.large"`). This option is meant as a quick flag so you don't need to look up filter name or instance types.
 
 Know that setting `--aws-ami-name-filter` and `--aws-instance-type` **and** `--aws-arm-build` will result in the `--aws-arm-build` defaults being used, **not** your passed in values.
 If you want to set specifics, please use `--aws-ami-name-filter` and `--aws-instance-type` directly.
+
+### GCE ARM builds
+This sets `GCE_IMAGE_FAMILY="ubuntu-1804-lts-arm64"` and `GCE_MACHINE_TYPE="t2a-standard-2"`, and will override **any**
+passed in values for both. If you need to set specifics, please pass in `--gce-family` and `--gce-machine-type` directly and omit
+`--gce-arm-build` instead.
 
 ## More questions?
 
@@ -178,3 +206,4 @@ Feel free to open an issue and we can add more to the README.
 [6]: https://launchpad.net/livecd-rootfs
 [7]: https://multipass.run/
 [8]: https://aws.amazon.com/
+[9]: https://console.cloud.google.com/

--- a/scripts/ubuntu-bartender/gce-provider
+++ b/scripts/ubuntu-bartender/gce-provider
@@ -43,7 +43,7 @@ function build-provider-create {
 
   echo "Creating $1 on GCE..."
   ip_addr=$(gcloud compute instances create "$1" \
-     --image-family ubuntu-1804-lts \
+     --image-family="$GCE_IMAGE_FAMILY" \
      --image-project ubuntu-os-cloud \
      --metadata-from-file=ssh-keys="$temp_dir/keys/metadata" \
      --boot-disk-size=50GB \

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -136,8 +136,10 @@ AZURE_INSTANCE_SIZE="Standard_F8s_v2"
 AZURE_LOCATION="France Central"
 
 # GCE SPECIFIC DEFAULTS
+GCE_ARM_BUILD=false
+GCE_IMAGE_FAMILY="ubuntu-1804-lts"
 GCE_MACHINE_TYPE="n2-standard-2"
-GCE_ZONE="europe-west3-a"
+GCE_ZONE="us-central1-a" # Low CO2 region with both ARM64 and AMD64 instances available
 
 # We also pull in explicitly set variables on the command line
 
@@ -192,7 +194,7 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             Value: ${CHROOT_ARCHIVE:-None}
 
     --build-provider <provider>             The provider used to build the image.
-                                            This can be either multipass or aws.
+                                            This can be multipass, aws, azure or gce.
                                             Value: $BUILD_PROVIDER
 
     --no-cleanup                            Don't tear down the build provider
@@ -236,11 +238,18 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             on Azure
                                             Value: $AZURE_LOCATION
 
-    --gce-machine-type <machine-type>       GCE instance machine type
+    --gce-machine-type <machine-type>       GCE instance machine type, defaults to n2-standard-2
                                             Value: $GCE_MACHINE_TYPE
 
-    --gce-zone <zone>                       Zone in which to create the GCE instance
+    --gce-zone <zone>                       Zone in which to create the GCE instance,
+                                            defaults to us-central1-a
                                             Value: $GCE_ZONE
+
+    --gce-family <image-family>             Defaults to bionic amd64 (ubuntu-1804-lts).
+                                            Value: $GCE_IMAGE_FAMILY
+
+    --gce-arm-build                         Short hand switch for safe arm64 defaults in GCE
+                                            (This overrides both --gce-machine-type *and* --gce-image-family)
 
     --temp-dir-loc                          Parent folder to build the temp dir used
                                             by bartender; note that this must be
@@ -382,6 +391,13 @@ do
       GCE_ZONE="$2"
       shift
       ;;
+    --gce-family)
+      GCE_IMAGE_FAMILY="$2"
+      shift
+      ;;
+    --gce-arm-build)
+      GCE_ARM_BUILD=true
+      ;;
     --temp-dir-loc)
       TEMP_DIR_LOC="$2"
       shift
@@ -423,6 +439,16 @@ then
   AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*"
   BUILD_PROVIDER="aws"
 fi
+
+# if --gce-arm-build is provided,
+# setup the new GCE defaults.
+if [ "$GCE_ARM_BUILD" = "true" ]
+then
+  GCE_IMAGE_FAMILY="ubuntu-1804-lts-arm64"
+  GCE_MACHINE_TYPE="t2a-standard-2"
+  BUILD_PROVIDER="gce"
+fi
+
 
 # Verify that the specified build provider is available and ready
 


### PR DESCRIPTION
* Previously most of the values for GCE were fixed, meaning some local hacking was needed to build ARM on GCE. Swapping 
   these defaults out for variables you can set is a better option going forward.
* Also added a quick flag to build ARM on GCE using defaults, similar to what we have already in AWS.