### PR TITLE
Setting up old fashioned on focal is allowed now

### DIFF
--- a/setup-old-fashioned
+++ b/setup-old-fashioned
@@ -98,8 +98,8 @@ def ubuntu_distro_info(options):
 
 
 if __name__ == '__main__':
-    if '18.04' not in DISTRO_VERSION and '16.04' not in DISTRO_VERSION:
-        print("Old-fashioned must be run on Bionic or Xenial Ubuntu.")
+    if '20.04' not in DISTRO_VERSION:
+        print("Old-fashioned must be run on Ubuntu Focal.")
         exit(1)
 
     for cmd in PKG_INSTALL_CMDS:


### PR DESCRIPTION
#86 migrated to focal but the setup-old-fashioned utility didn't get updated to accept that serie

it isn't enough to make the script work though since it tries to install 'oldfashioned' from http://ppa.launchpad.net/cloud-images/old-fashioned/ubuntu which seems to not exist anymore?