### PR TITLE
Add --debug to old-fashioned-image-build

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -19,12 +19,16 @@ IMAGE_TARGET=""
 REPO_SNAPSHOT=""
 SNAP_COHORT=""
 EXTRA_PPA=""
+DEBUG=""
 
 while :; do
     case "$1" in
         --minimized)
             # Pass this flag to build the 'minimal' image family
             SUBPROJECT="--subproject minimized"
+            ;;
+        --debug)
+            DEBUG="--debug"
             ;;
         --build-from-proposed)
             # Build from -proposed pocket
@@ -255,7 +259,7 @@ time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT \
   $EXTRA_PPA \
-  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED_BUILD
+  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED_BUILD $DEBUG
 
 echo "Copying files out to $OUTPUT_DIRECTORY"
 rm -rf $OUTPUT_DIRECTORY


### PR DESCRIPTION
launchpad-buildd buildlivefs does accept a "--debug" flag[0] which writes each command to standard error (preceded by a '+') before it is executed. That's very useful for debugging so add the possibility to pass this flag down to launchpad-buildd.

[0]
https://git.launchpad.net/launchpad-buildd/tree/lpbuildd/target/build_livefs.py#n106