### PR TITLE
fix[#91]: sbom-tools match flag convention and default

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -66,6 +66,7 @@ UBUNTU_OLD_FASHIONED_BRANCH=${UBUNTU_OLD_FASHIONED_BRANCH:-master}
 HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH=${HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH:-}
 HOOK_EXTRAS_SBOM_TOOLS_BRANCH=${HOOK_EXTRAS_SBOM_TOOLS_BRANCH:-}
 HOOK_EXTRAS_SBOM_TOOLS_DIR=${HOOK_EXTRAS_SBOM_TOOLS_DIR:-}
+HOOK_EXTRAS_SBOM_TOOLS_SUBDIR="${HOOK_EXTRAS_SBOM_TOOLS_SUBDIR:-cpc_sbom}"
 
 # LIVECD_ROOTFS_BRANCH is inferred below from the script name
 HOOK_EXTRAS_BRANCH=${HOOK_EXTRAS_BRANCH:-}
@@ -182,8 +183,14 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
     --hook-extras-sbom-tools-branch <branch> The branch of the sbom-tools to use.
                                             Value: ${HOOK_EXTRAS_SBOM_TOOLS_BRANCH:-None}
 
-    --hook-extras-sbom-tools-dir <dir>      The directory in the sbom-tools to copy in to hooks.d/extra directories.
+    --hook-extras-sbom-tools-subdir <dir>   The directory in the sbom-tools to copy in to hooks.d/extra directories.
                                             This is useful as you don't always want to copy the entire sbom-tools repo.
+                                            If using https://github.com/canonical/cpc-sbom as your tool
+                                            you _must_ use  "cpc_sbom" as the value (this is the default)
+                                            to ensure that the Python code is at the root, not packaging information. 
+                                            Value: ${HOOK_EXTRAS_SBOM_TOOLS_SUBDIR}
+
+    --hook-extras-sbom-tools-dir  <dir>     A local directory containing sbom-tools
                                             Value: ${HOOK_EXTRAS_SBOM_TOOLS_DIR:-None}
 
     --hook-extras-dir <dir>                 A local directory containing extra hooks.
@@ -329,6 +336,10 @@ do
       ;;
     --hook-extras-sbom-tools-branch)
       HOOK_EXTRAS_SBOM_TOOLS_BRANCH="$2"
+      shift
+      ;;
+    --hook-extras-sbom-tools-subdir)
+      HOOK_EXTRAS_SBOM_TOOLS_SUBDIR="$2"
       shift
       ;;
     --hook-extras-sbom-tools-dir)
@@ -565,6 +576,11 @@ build-provider-create $bartender_name
       xargs -I {} sh -c "mkdir --parents {}/extra/release-notes-tools && cp --archive --force $temp_dir/release-notes-tools/* {}/extra/release-notes-tools/"
   fi
 
+  if [ -n "$HOOK_EXTRAS_SBOM_TOOLS_DIR" ];
+    then
+      cp -aR "$HOOK_EXTRAS_SBOM_TOOLS_DIR" $temp_dir/sbom-tools
+  fi
+
   if [ -n "$HOOK_EXTRAS_SBOM_TOOLS_REPO" ]
   then
     branch_flag=" "
@@ -579,7 +595,7 @@ build-provider-create $bartender_name
   then
     # copy the sbom tools to all the hooks directories
     find livecd-rootfs/live-build/ -type d -name '*hooks*' |
-      xargs -I {} sh -c "mkdir --parents {}/extra/sbom-tools && cp --archive --force $temp_dir/sbom-tools/${HOOK_EXTRAS_SBOM_TOOLS_DIR}/* {}/extra/sbom-tools/"
+      xargs -I {} sh -c "mkdir --parents {}/extra/sbom-tools && cp --archive --force $temp_dir/sbom-tools/${HOOK_EXTRAS_SBOM_TOOLS_SUBDIR}/* {}/extra/sbom-tools/"
   fi
 
   cat > mix-old-fashioned << EOF


### PR DESCRIPTION
--hook-extras-sbom-tools-dir was different than all the other *-dir flags, in that it didn't indicate a local checkout/directory to nest into bartender, but instead indicated a subdirectory of an sbom-tool to nest. This made usage unclear. Separated sbom-tools-subdir and sbom-tools-dir into separate params, following the same convention as other *-dir params.

Further the description for the -dir mentioned it was useful. It's not useful, it's a strict requirement to pass when building Canonical Public Cloud projects that create an SBOM. this is due to the code that generates the sbom, at this time, referencing the __init__.py in the cpc-sbom tool. The project is a separate src Python style, so the __init__.py lives in a nested directory. To run CPC builds, one must pass in the var, with a specific string. Since it is the default for using the currently supported sbom-tool, I've made it the default to the value. This value is unused if no other sbom-tools values are provided.