### PR TITLE
fix(docs): Change incorrect references to bionic

### DIFF
--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -190,7 +190,7 @@ Know that setting `--aws-ami-name-filter` and `--aws-instance-type` **and** `--a
 If you want to set specifics, please use `--aws-ami-name-filter` and `--aws-instance-type` directly.
 
 ### GCE ARM builds
-This sets `GCE_IMAGE_FAMILY="ubuntu-1804-lts-arm64"` and `GCE_MACHINE_TYPE="t2a-standard-2"`, and will override **any**
+This sets `GCE_IMAGE_FAMILY="ubuntu-2004-lts-arm64"` and `GCE_MACHINE_TYPE="t2a-standard-2"`, and will override **any**
 passed in values for both. If you need to set specifics, please pass in `--gce-family` and `--gce-machine-type` directly and omit
 `--gce-arm-build` instead.
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -243,7 +243,7 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             defaults to us-central1-a
                                             Value: $GCE_ZONE
 
-    --gce-family <image-family>             Defaults to bionic amd64 (ubuntu-1804-lts).
+    --gce-family <image-family>             Defaults to focal amd64 (ubuntu-2004-lts).
                                             Value: $GCE_IMAGE_FAMILY
 
     --gce-arm-build                         Short hand switch for safe arm64 defaults in GCE


### PR DESCRIPTION
We migrated over to building with focal a few months ago now, but a couple of the GCE docs/comments were left behind and referring to bionic.