### PR TITLE
feat: Add ability to inject your own livebuild from git or local directory

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -232,32 +232,78 @@ fi
 
 # Inject the files from the current tree in the right place in the LXD
 # container.
-# First install livecd-rootfs. We will replace the bulk of the livecd-rootfs
+# First install livecd-rootfs and live-build. We will replace the bulk of the livecd-rootfs
 # code with our local copy. Without this livecd-rootfs is installed by
 # buildlivefs (below) overwriting changes
-lxc exec lp-$SERIES-${ARCH} -- apt-get install -y livecd-rootfs
+# If we have specified a local live-build directory then we will replace the
+# installed live-build code with our local copy. Without this live-build is
+# installed by buildlivefs (below) overwriting changes
+lxc exec lp-$SERIES-${ARCH} -- apt-get install --assume-yes livecd-rootfs live-build
 
 # Remove and recreate the livecd-rootfs code we will be replacing with code
 # in our current directory
-lxc exec lp-$SERIES-${ARCH} -- rm -rf /usr/share/livecd-rootfs
-lxc exec lp-$SERIES-${ARCH} -- mkdir -p /usr/share/livecd-rootfs
+lxc exec lp-$SERIES-${ARCH} -- rm --recursive --force /usr/share/livecd-rootfs
+lxc exec lp-$SERIES-${ARCH} -- mkdir --parents /usr/share/livecd-rootfs
 # Old LXCs don't have recursive push... so we tar and untar instead.
-tar czvf $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz .
-lxc file push $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz lp-$SERIES-${ARCH}/usr/share/livecd-rootfs/
-lxc exec lp-$SERIES-${ARCH} -- tar xzvf /usr/share/livecd-rootfs/live-build.tar.gz -C /usr/share/livecd-rootfs/
+ls --all -l
+tar --create --gzip --verbose --file $OLD_FASHIONED_BUILD_CACHE/livecd-rootfs.tar.gz .
+lxc file push $OLD_FASHIONED_BUILD_CACHE/livecd-rootfs.tar.gz lp-$SERIES-${ARCH}/usr/share/livecd-rootfs/
+lxc exec lp-$SERIES-${ARCH} -- tar --extract --gzip --verbose --file /usr/share/livecd-rootfs/livecd-rootfs.tar.gz -C /usr/share/livecd-rootfs/
+# remove the tarball as it is no longer needed
+lxc exec lp-$SERIES-${ARCH} -- rm --verbose /usr/share/livecd-rootfs/livecd-rootfs.tar.gz
+
+# If the $HOME/live-build directory exists, copy it into the LXD container overwriting the installed live-build scripts
+if [ -d $HOME/live-build ] ; then
+  pushd $HOME/live-build
+  # create a tarball of the live-build code
+  tar --create --gzip --verbose --file $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz .
+  # create a temporary directory in the container to hold the live-build code
+  lxc exec lp-$SERIES-${ARCH} -- mkdir --parents /tmp/live-build
+  # push the tarball into the container to the temporary directory
+  lxc file push $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz lp-$SERIES-${ARCH}/tmp/live-build/
+  # extract the tarball into the temporary live-build directory
+  lxc exec lp-$SERIES-${ARCH} -- tar --extract --gzip --verbose --file /tmp/live-build/live-build.tar.gz -C /tmp/live-build/
+  # remove the tarball as it is no longer needed
+  lxc exec lp-$SERIES-${ARCH} -- rm --verbose /tmp/live-build/live-build.tar.gz
+
+  # Now copy the live-build code into the installed locations in the container
+  # These steps were taken from the install section of the live-build debian/rules file
+  #mkdir -p $(DESTDIR)/usr/share/live/build
+  lxc exec lp-$SERIES-${ARCH} -- mkdir --verbose --parents /usr/share/live/build
+  #cp -r frontends/cgi data functions templates VERSION $(DESTDIR)/usr/share/live/build
+  lxc exec lp-$SERIES-${ARCH} -- cp --recursive --verbose /tmp/live-build/frontends/cgi /tmp/live-build/data /tmp/live-build/functions /tmp/live-build/templates /tmp/live-build/VERSION /usr/share/live/build
+  #cp -r share/* $(DESTDIR)/usr/share/live/build
+  lxc exec lp-$SERIES-${ARCH} -- bash -c "cp --archive --verbose /tmp/live-build/share/* /usr/share/live/build"
+
+  #
+  ## Installing executables
+  #mkdir -p $(DESTDIR)/usr/bin
+  lxc exec lp-$SERIES-${ARCH} -- mkdir --verbose --parents /usr/bin
+  #cp -a bin/* $(DESTDIR)/usr/bin
+  lxc exec lp-$SERIES-${ARCH} -- bash -c "cp --archive --verbose /tmp/live-build/bin/* /usr/bin"
+  #
+  #mkdir -p $(DESTDIR)/usr/lib/live
+  lxc exec lp-$SERIES-${ARCH} -- mkdir --verbose --parents /usr/lib/live
+  #cp -a scripts/* $(DESTDIR)/usr/lib/live
+  lxc exec lp-$SERIES-${ARCH} -- bash -c "cp --archive --verbose /tmp/live-build/scripts/* /usr/lib/live"
+
+  lxc exec lp-$SERIES-${ARCH} -- chmod +x /usr/lib/live/build/lb_chroot_early_hooks
+
+  popd
+fi
 
 # Use qemu-backports to build xenial images. Otherwise, the images may not boot.
 if [ "$SERIES" = "xenial" ]; then
-  lxc exec lp-$SERIES-${ARCH} -- apt-get install -y software-properties-common
-  lxc exec lp-$SERIES-${ARCH} -- add-apt-repository -y ppa:cloud-images-release-managers/qemu-backports
+  lxc exec lp-$SERIES-${ARCH} -- apt-get install --assume-yes software-properties-common
+  lxc exec lp-$SERIES-${ARCH} -- add-apt-repository --yes ppa:cloud-images-release-managers/qemu-backports
   lxc exec lp-$SERIES-${ARCH} -- apt-get update
-  lxc exec lp-$SERIES-${ARCH} -- apt-get install -y qemu-utils
+  lxc exec lp-$SERIES-${ARCH} -- apt-get install --assume-yes qemu-utils
 fi
 
 # Actually build.
 time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
-  --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT \
+  --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT --debug \
   $EXTRA_PPA \
   $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED_BUILD $DEBUG
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -155,6 +155,15 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
     --livecd-rootfs-dir <dir>               A local directory containing livecd-rootfs.
                                             Value: ${LIVECD_ROOTFS_DIR:-None}
 
+    --live-build-repo <url>                 The url to the git repo hosting live-build.
+                                            Value: $LIVE_BUILD_REPO
+
+    --live-build-branch <branch>             The branch of live-build to use.
+                                            Value: $LIVE_BUILD_BRANCH
+
+    --live-build-dir <dir>                  A local directory containing live-build.
+                                            Value: ${LIVE_BUILD_DIR:-None}
+
     --ubuntu-old-fashioned-repo <url>       The url to the git repo hosting ubuntu-old-fashioned.
                                             Value: $UBUNTU_OLD_FASHIONED_REPO
 
@@ -289,6 +298,18 @@ do
       ;;
     --livecd-rootfs-dir)
       LIVECD_ROOTFS_DIR="$2"
+      shift
+      ;;
+    --live-build-repo)
+      LIVE_BUILD_REPO="$2"
+      shift
+      ;;
+    --live-build-branch)
+      LIVE_BUILD_BRANCH="$2"
+      shift
+      ;;
+    --live-build-dir)
+      LIVE_BUILD_DIR="$2"
       shift
       ;;
     --ubuntu-old-fashioned-repo)
@@ -501,22 +522,32 @@ build-provider-create $bartender_name
 
   if [ -n "$HOOK_EXTRAS_DIR" ]
   then
-    cp -aR "$HOOK_EXTRAS_DIR" $temp_dir/extras
+    echo "HOOK_EXTRAS_DIR is set, copying $HOOK_EXTRAS_DIR to $temp_dir/extras ..."
+    cp --archive --recursive "$HOOK_EXTRAS_DIR" $temp_dir/extras
   fi
 
   if [ -n "$LIVECD_ROOTFS_DIR" ]
   then
-    cp -aR "$LIVECD_ROOTFS_DIR" $temp_dir/livecd-rootfs
+    echo "LIVECD_ROOTFS_DIR is set, copying $LIVECD_ROOTFS_DIR to $temp_dir/livecd-rootfs ..."
+    cp --archive --recursive "$LIVECD_ROOTFS_DIR" $temp_dir/livecd-rootfs
+  fi
+
+  if [ -n "$LIVE_BUILD_DIR" ]
+  then
+    echo "LIVE_BUILD_DIR is set, copying $LIVE_BUILD_DIR to $temp_dir/live-build ..."
+    cp --archive --recursive "$LIVE_BUILD_DIR" $temp_dir/live-build
   fi
 
   if [ -n "$UBUNTU_OLD_FASHIONED_DIR" ]
   then
-    cp -aR "$UBUNTU_OLD_FASHIONED_DIR" $temp_dir/ubuntu-old-fashioned
+    echo "UBUNTU_OLD_FASHIONED_DIR is set, copying $UBUNTU_OLD_FASHIONED_DIR to $temp_dir/ubuntu-old-fashioned ..."
+    cp --archive --recursive "$UBUNTU_OLD_FASHIONED_DIR" $temp_dir/ubuntu-old-fashioned
   fi
 
   if [ -n "$CHROOT_ARCHIVE" ]
   then
-    cp -aR "$CHROOT_ARCHIVE" $temp_dir/chroot-archive
+    echo "CHROOT_ARCHIVE is set, copying $CHROOT_ARCHIVE to $temp_dir/chroot-archive ..."
+    cp --archive --recursive "$CHROOT_ARCHIVE" $temp_dir/chroot-archive
     chroot_archive_flag="--use-chroot-archive ../chroot-archive"
   fi
 
@@ -524,12 +555,21 @@ build-provider-create $bartender_name
 
   if [ -z "$UBUNTU_OLD_FASHIONED_DIR" ]
   then
-    git clone -qb $UBUNTU_OLD_FASHIONED_BRANCH $UBUNTU_OLD_FASHIONED_REPO
+    echo "UBUNTU_OLD_FASHIONED_DIR is not set, cloning $UBUNTU_OLD_FASHIONED_REPO to $temp_dir/ubuntu-old-fashioned ..."
+    git clone --quiet --depth 1 --branch $UBUNTU_OLD_FASHIONED_BRANCH $UBUNTU_OLD_FASHIONED_REPO ubuntu-old-fashioned
   fi
 
   if [ -z "$LIVECD_ROOTFS_DIR" ]
   then
-    git clone -qb $LIVECD_ROOTFS_BRANCH $LIVECD_ROOTFS_REPO
+    echo "LIVECD_ROOTFS_DIR is not set, cloning $LIVECD_ROOTFS_REPO to $temp_dir/livecd-rootfs ..."
+    git clone --quiet --depth 1 --branch $LIVECD_ROOTFS_BRANCH $LIVECD_ROOTFS_REPO livecd-rootfs
+  fi
+
+  if [ -z "$LIVE_BUILD_DIR" ] && [ -n "$LIVE_BUILD_REPO" ] && [ -n "$LIVE_BUILD_BRANCH" ]
+  then
+    echo "LIVE_BUILD_DIR is not set, LIVE_BUILD_REPO and LIVE_BUILD_BRANCH are set. "
+    echo "cloning $LIVE_BUILD_REPO to $temp_dir/live-build ..."
+    git clone --quiet --depth 1 --branch $LIVE_BUILD_BRANCH $LIVE_BUILD_REPO live-build
   fi
 
   if [ -n "$HOOK_EXTRAS_REPO" ]
@@ -537,15 +577,15 @@ build-provider-create $bartender_name
     branch_flag=" "
     if [ -n "$HOOK_EXTRAS_BRANCH" ]
     then
-      branch_flag="-b $HOOK_EXTRAS_BRANCH"
+      branch_flag="--branch $HOOK_EXTRAS_BRANCH"
     fi
-    git clone -q $branch_flag $HOOK_EXTRAS_REPO extras
+    git clone --quiet --depth 1 $branch_flag $HOOK_EXTRAS_REPO extras
   fi
 
   if [ -d $temp_dir/extras ]
   then
     find livecd-rootfs/live-build/ -type d -name '*hooks*' |
-      xargs -I {} cp -af extras/* {}
+      xargs -I {} cp --archive --force extras/* {}
   fi
 
   if [ -n "$HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO" ]
@@ -553,9 +593,9 @@ build-provider-create $bartender_name
     branch_flag=" "
     if [ -n "$HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH" ]
     then
-      branch_flag="-b $HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH"
+      branch_flag="--branch $HOOK_EXTRAS_RELEASE_NOTES_TOOLS_BRANCH"
     fi
-    git clone -q $branch_flag $HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO release-notes-tools
+    git clone --quiet --depth 1 -q $branch_flag $HOOK_EXTRAS_RELEASE_NOTES_TOOLS_REPO release-notes-tools
   fi
 
   if [ -d $temp_dir/release-notes-tools ]
@@ -570,9 +610,9 @@ build-provider-create $bartender_name
     branch_flag=" "
     if [ -n "$HOOK_EXTRAS_SBOM_TOOLS_BRANCH" ]
     then
-      branch_flag="-b $HOOK_EXTRAS_SBOM_TOOLS_BRANCH"
+      branch_flag="--branch $HOOK_EXTRAS_SBOM_TOOLS_BRANCH"
     fi
-    git clone -q $branch_flag $HOOK_EXTRAS_SBOM_TOOLS_REPO sbom-tools
+    git clone --quiet --depth 1 -q $branch_flag $HOOK_EXTRAS_SBOM_TOOLS_REPO sbom-tools
   fi
 
   if [ -d $temp_dir/sbom-tools ]
@@ -591,9 +631,13 @@ cd livecd-rootfs
 sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
 EOF
 
-  tar czf ingredients.tar.gz --exclude-vcs ./*
+  tar --create --gzip --file ingredients.tar.gz --exclude-vcs ./*
+  echo "uploading ingredients.tar.gz to $bartender_name ..."
   build-provider-upload $bartender_name ingredients.tar.gz ingredients.tar.gz
+  echo "extracting ingredients.tar.gz in $bartender_name ..."
   build-provider-run $bartender_name -- tar xf ingredients.tar.gz
+  echo "remove ingredients.tar.gz in $bartender_name as it is no longer required ..."
+  build-provider-run $bartender_name -- rm -v ingredients.tar.gz
 )
 
 echo "Mixing drink..."


### PR DESCRIPTION
Use `LIVE_BUILD_DIR` environment variable or `--live-build-dir` option to pass in your own live-build local directory

Use `LIVE_BUILD_REPO` and `LIVE_BUILD_BRANCH` environment variables or `--live-build-repo` and `--live-build-branch` options to pass in your own live-build git repo and branch.

This is very useful for being able to debug live-build.