### PR TITLE
Pick AWS_PROFILE from environment

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -106,7 +106,7 @@ fi
 # Please preface each provider default with the provider name
 
 # AWS SPECIFIC DEFAULTS
-AWS_PROFILE="default"
+: ${AWS_PROFILE:=default}
 AWS_INSTANCE_TYPE="m5.large"
 # Official Canonical OwnerId
 AWS_AMI_OWNER=099720109477


### PR DESCRIPTION
AWS_PROFILE is currently forcibly set to default. It can be overwritten
by the --aws-profile flag. But that requires other scripts that use this
script to support passing --aws-profile. Instead of modyfing these other
scripts, pick the AWS_PROFILE from environment and set it to default
only when it's empty or unset.