### PR TITLE
fix(setup): handle none choice for livecd-rootfs

### DIFF
--- a/setup-old-fashioned
+++ b/setup-old-fashioned
@@ -140,8 +140,9 @@ if __name__ == '__main__':
         cmd = []
         print("'none' option selected. Skipping livecd-rootfs install...")
 
-    print("Executing {}".format(' '.join(cmd)))
-    call(cmd)
+    if cmd:
+        print("Executing {}".format(' '.join(cmd)))
+        call(cmd)
 
     print("Done installing tools. All that's left to do is clone and copy any "
           "additional hooks you might want to run.")


### PR DESCRIPTION
The last option #6 in the livecd-rootfs menu is none, a choice that I use as I'm just bringing in the copy I want already.  subprocess.call() doesn't like that empty command array.