### PR TITLE
fix: Transition to 24.04 images for build

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -209,9 +209,9 @@ EOF
 fi
 
 # Use the same apt mirror as the host
-export MIRROR=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
+export MIRROR=$(egrep "^URIs:" /etc/apt/sources.list.d/ubuntu.sources|head -1 | \
                cut -d' ' -f2 | cut -d'/' -f3)
-export MIRROR_PATH=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
+export MIRROR_PATH=$(egrep "^URIs:" /etc/apt/sources.list.d/ubuntu.sources|head -1 | \
                cut -d' ' -f2 | cut -d'/' -f4)
 
 proposed_source=""

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -694,5 +694,5 @@ echo "(See progress in $bartender_name.log)"
 build-provider-run $bartender_name -- bash mix-old-fashioned &>$bartender_name.log </dev/null
 
 echo "Pouring $drink_name..."
-build-provider-run $bartender_name -- tar czf drink.tar.gz build.output
+build-provider-run $bartender_name -- sudo tar czf drink.tar.gz build.output
 build-provider-download $bartender_name drink.tar.gz $drink_name

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -115,7 +115,7 @@ AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
-MULTIPASS_IMAGE=daily:f # daily image of focal
+MULTIPASS_IMAGE=daily:n # daily image of noble
 # you can optionally override memory cap by setting MULTIPASS_MEM_SIZE
 
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).
@@ -133,13 +133,13 @@ fi
 MULTIPASS_MEM_SIZE=${MULTIPASS_MEM_SIZE:-$MULTIPASS_MEM_SIZE_DEFAULT}
 
 # AZURE SPECIFIC DEFAULTS
-AZURE_URN="Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts-gen2:latest"
+AZURE_URN="Canonical:ubuntu-24_04-lts:server:latest"
 AZURE_INSTANCE_SIZE="Standard_F8s_v2"
 AZURE_LOCATION="France Central"
 
 # GCE SPECIFIC DEFAULTS
 GCE_ARM_BUILD=false
-GCE_IMAGE_FAMILY="ubuntu-2004-lts"
+GCE_IMAGE_FAMILY="ubuntu-2404-lts-amd64"
 GCE_MACHINE_TYPE="n2-standard-2"
 GCE_ZONE="us-central1-a" # Low CO2 region with both ARM64 and AMD64 instances available
 
@@ -225,9 +225,9 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             Value: Cleanup? $SHOULD_CLEANUP
 
     --aws-ami-name-filter <image-name>      Filter for finding an AWS ami by name
-                                            defaults to Focal AMD64. This is
+                                            defaults to Noble AMD64. This is
                                             the base for the builds. 
-                                            Value: ubuntu/images-testing/hvm-ssd/ubuntu-focal-daily-${ARCH}-server-*
+                                            Value: ubuntu/images-testing/hvm-ssd-gp3/ubuntu-noble-daily-${ARCH}-server-*
 
     --aws-profile <profile>                 AWS profile used with the aws cli
                                             Value: $AWS_PROFILE
@@ -267,7 +267,7 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             defaults to us-central1-a
                                             Value: $GCE_ZONE
 
-    --gce-family <image-family>             Defaults to focal amd64 (ubuntu-2004-lts).
+    --gce-family <image-family>             Defaults to noble amd64 (ubuntu-2404-lts-amd64).
                                             Value: $GCE_IMAGE_FAMILY
 
     --gce-arm-build                         Short hand switch for safe arm64 defaults in GCE
@@ -492,12 +492,12 @@ fi
 # setup the new GCE defaults.
 if [ "$GCE_ARM_BUILD" = "true" ]
 then
-  GCE_IMAGE_FAMILY="ubuntu-2004-lts-arm64"
+  GCE_IMAGE_FAMILY="ubuntu-2404-lts-arm64"
   GCE_MACHINE_TYPE="t2a-standard-2"
   BUILD_PROVIDER="gce"
 fi
 
-AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-focal-daily-${AWS_ARCH}-server-*"
+AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd-gp3/ubuntu-noble-daily-${AWS_ARCH}-server-*"
 
 # Verify that the specified build provider is available and ready
 

--- a/setup-old-fashioned
+++ b/setup-old-fashioned
@@ -99,8 +99,8 @@ def ubuntu_distro_info(options):
 
 
 if __name__ == '__main__':
-    if '20.04' not in DISTRO_VERSION:
-        print("Old-fashioned must be run on Ubuntu Focal.")
+    if '24.04' not in DISTRO_VERSION:
+        print("Old-fashioned must be run on Ubuntu Noble.")
         exit(1)
 
     for cmd in PKG_INSTALL_CMDS:


### PR DESCRIPTION
Currently, all cloud providers use 20.04 images
for image build. Since focal will reach EOL in
May, the focal image should be transitioned to
other supported OS versions.

Since the Launchpad builders mostly use 24.04,
switch to noble images to match the builder's
OS version.