### PR TITLE
Fix-ip-azure-provider

### DIFF
--- a/scripts/ubuntu-bartender/azure-provider
+++ b/scripts/ubuntu-bartender/azure-provider
@@ -51,7 +51,7 @@ function build-provider-create {
   for attempt in $(seq 6); do
     rg_state=requested
     rg_exists=$(az group exists --name "$1")
-    if [ rg_exists = "false" ]; then
+    if [ "$rg_exists" = "false" ]; then
       sleep 10
     else
       rg_state=created


### PR DESCRIPTION
This changes will prevent the following error to appear when using bartender with azure as builder:


ubuntu-bartender \                          
      --build-provider azure \
      --livecd-rootfs-branch ubuntu/plucky \
      --hook-extras-dir "/media/miriam/extension/CPC/cloudware/git/cpc_packaging.extra" \
      -- --series plucky \
      --project ubuntu-cpc \
      --image-target azure

[...]
Creating open-troll-ubuntu-bartender Resource Group and VM on Azure...
jq: parse error: Invalid numeric literal at line 1, column 14

