### PR TITLE
feat: add LXD provider

### DIFF
--- a/scripts/ubuntu-bartender/lxd-provider
+++ b/scripts/ubuntu-bartender/lxd-provider
@@ -1,0 +1,48 @@
+function _wait_agent_start() {
+  for attempt in $(seq 12); do
+    if ! lxc exec "$1" -- true &> /dev/null; then
+      sleep 5
+    else
+      state=connectable
+      break
+    fi
+  done
+
+  if [ "$state" != "connectable" ]; then
+    echo "error: LXD agent not running after 1 minutes"
+    exit 255
+  fi
+}
+
+function build-provider-assert-ready {
+  if ! command -v lxc &>/dev/null
+  then
+    echo "error: lxc was not found in PATH" >&2
+    exit 255
+  fi
+}
+
+function build-provider-destroy {
+  lxc delete -f "$1"
+}
+
+function build-provider-create {
+  lxc launch --vm "$LXD_IMAGE" "$1" \
+    --config limits.cpu="${LXD_CPU}" \
+    --config limits.memory="${LOCAL_VM_MEM_SIZE}iB" \
+    --device root,size="${LOCAL_VM_DISK_SIZE}iB"
+
+  _wait_agent_start "$1"
+}
+
+function build-provider-upload {
+  lxc file push "$2" "$1/root/$3"
+}
+
+function build-provider-download {
+  lxc file pull "$1/root/$2" "$3"
+}
+
+function build-provider-run {
+  lxc exec $@
+}

--- a/scripts/ubuntu-bartender/multipass-provider
+++ b/scripts/ubuntu-bartender/multipass-provider
@@ -11,7 +11,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
-  multipass launch --disk $MULTIPASS_DISK_SIZE --memory $MULTIPASS_MEM_SIZE --name "$1" $MULTIPASS_IMAGE
+  multipass launch --disk $LOCAL_VM_DISK_SIZE --memory $LOCAL_VM_MEM_SIZE --name "$1" $MULTIPASS_IMAGE
 }
 
 function build-provider-upload {

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -113,9 +113,10 @@ AWS_AMI_OWNER=099720109477
 AWS_KEYPAIR_NAME=$USER
 AWS_ARM_BUILD=false
 
-# MULTIPASS SPECIFIC DEFAULTS
-MULTIPASS_DISK_SIZE=50G
+# MULTIPASS/LXD SPECIFIC DEFAULTS
+LOCAL_VM_DISK_SIZE=50G
 MULTIPASS_IMAGE=daily:n # daily image of noble
+LXD_IMAGE="ubuntu:noble" # release image of noble
 # you can optionally override memory cap by setting MULTIPASS_MEM_SIZE
 
 # By default, do not exceed half the total memory or 8GiB (whichever is smaller).
@@ -125,12 +126,24 @@ HALF_MEM="$(( $TOTAL_MEM / 2 ))"
 CAP_MEM=8192
 
 if [[ "$HALF_MEM" -lt "$CAP_MEM" ]]; then
-    MULTIPASS_MEM_SIZE_DEFAULT="${HALF_MEM}M"
+    LOCAL_VM_MEM_SIZE_DEFAULT="${HALF_MEM}M"
 else
-    MULTIPASS_MEM_SIZE_DEFAULT="${CAP_MEM}M"
+    LOCAL_VM_MEM_SIZE_DEFAULT="${CAP_MEM}M"
 fi
 
-MULTIPASS_MEM_SIZE=${MULTIPASS_MEM_SIZE:-$MULTIPASS_MEM_SIZE_DEFAULT}
+LOCAL_VM_MEM_SIZE=${LOCAL_VM_MEM_SIZE:-$LOCAL_VM_MEM_SIZE_DEFAULT}
+
+# By default, do not exceed 1/6 the total cores or 4 cores (whichever is smaller).
+ONE_SIXTH_CORES="$(( $(nproc) / 6 ))"
+CAP_CPU=4
+
+if [[ "$ONE_SIXTH_CORES" -lt "$CAP_CPU" ]]; then
+    LXD_CPU_DEFAULT="${ONE_SIXTH_CORES}"
+else
+    LXD_CPU_DEFAULT="${CAP_CPU}"
+fi
+
+LXD_CPU=${LXD_CPU:-$LXD_CPU_DEFAULT}
 
 # AZURE SPECIFIC DEFAULTS
 AZURE_URN="Canonical:ubuntu-24_04-lts:server:latest"


### PR DESCRIPTION
LXD is the default backend for multipass on Ubuntu. We don't use any of the multipass features beyond what LXD can already provide and LXD is installed by default on Ubuntu (unlike multipass).