### PR TITLE
feat: add --isa-tag support for microarchitecture variants like amd64v3

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -117,6 +117,13 @@ while :; do
             SNAP_COHORT="--cohort-key $2"
             shift
             ;;
+        --isa-tag)
+            # Override the ISA tag passed to launchpad-buildd.
+            # Use this to build microarchitecture variants e.g. 'amd64v3'.
+            # The ABI tag (and chroot/container naming) stays as the base arch.
+            ISA_TAG_OVERRIDE="$2"
+            shift
+            ;;
         -?*)
             echo "WARNING: Unknown option or argument ignored: $1"
             exit 1
@@ -134,6 +141,8 @@ case `arch` in
     ppc64le) ARCH=ppc64el;;
     *) echo "Unrecognized arch: $(arch)"; exit 1;;
 esac
+
+ISA_TAG=${ISA_TAG_OVERRIDE:-${ARCH}}
 
 if [ x$SERIES = "x" ] ; then
     echo "Missing required '--series' argument e.g. '--series xenial'"
@@ -192,9 +201,9 @@ sudo sed -i 's/ntp\.buildd/0\.pool\.ntp\.org/g' \
 
 /usr/share/launchpad-buildd/bin/builder-prep
 /usr/share/launchpad-buildd/bin/in-target unpack-chroot --backend=lxd \
-  --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME $CHROOT_ARCHIVE
+  --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME $CHROOT_ARCHIVE
 /usr/share/launchpad-buildd/bin/in-target mount-chroot --backend=lxd \
-  --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME
+  --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME
 
 # Inject squid proxy config in the LXC if one exists in the host.
 SQUID_ADDRESS=$(cat /etc/apt/apt.conf.d/* | sed -n 's/Acquire::http::Proxy "\(.*\)";/\1/p')
@@ -221,14 +230,14 @@ if [ "$PROPOSED_IN_IMAGE" = "true" ]; then
 fi
 
 /usr/share/launchpad-buildd/bin/in-target override-sources-list \
-  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME \
+  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse" \
     "${proposed_source}"
   
 /usr/share/launchpad-buildd/bin/in-target update-debian-chroot \
-  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME
+  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME
 
 # Inject the files from the current tree in the right place in the LXD
 # container.
@@ -302,7 +311,7 @@ fi
 
 # Actually build.
 time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
-  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
+  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT --debug \
   $EXTRA_PPA \
   $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED_BUILD $DEBUG
@@ -324,10 +333,10 @@ fi
 
 # Cleanup the builder LXD.
 /usr/share/launchpad-buildd/bin/in-target scan-for-processes \
-  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME
+  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME
 
 /usr/share/launchpad-buildd/bin/in-target umount-chroot \
-  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME
+  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME
 
 /usr/share/launchpad-buildd/bin/in-target remove-build \
-  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ARCH} $LIVEFS_NAME
+  --backend=lxd --series=$SERIES --abi-tag=${ARCH} --isa-tag=${ISA_TAG} $LIVEFS_NAME

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -460,6 +460,10 @@ do
     --gce-arm-build)
       GCE_ARM_BUILD=true
       ;;
+    --isa-tag)
+      ISA_TAG="$2"
+      shift
+      ;;
     --temp-dir-loc)
       TEMP_DIR_LOC="$2"
       shift
@@ -700,7 +704,7 @@ sudo add-apt-repository -y -u ppa:launchpad/ubuntu/buildd
 sudo apt-get -q update
 sudo apt-get -q install -y launchpad-buildd bzr git python3-ubuntutools python3-launchpadlib
 cd livecd-rootfs
-sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
+sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag ${ISA_TAG:+--isa-tag $ISA_TAG} $@
 EOF
 
   tar --create --gzip --file ingredients.tar.gz --exclude-vcs ./*


### PR DESCRIPTION
## Description
Previously, both --abi-tag and --isa-tag passed to launchpad-buildd were always set to the same value.

This change adds a new --isa-tag argument to both old-fashioned-image-build and ubuntu-bartender. When provided, it overrides only the --isa-tag passed to launchpad-buildd.

To build an amd64v3 resolute images, pass --isa-tag amd64v3 to ubuntu-bartender.
## How this was tested
tested locally by running resolute build for amd64v3 variant